### PR TITLE
Disable django admin

### DIFF
--- a/src/settings/base.py
+++ b/src/settings/base.py
@@ -36,7 +36,6 @@ INSTALLED_APPS = [
     # enable whitenoise static serving for runserver command (for development)
     'whitenoise.runserver_nostatic',
 
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',

--- a/src/urls.py
+++ b/src/urls.py
@@ -16,7 +16,6 @@ Including another URLconf
 
 from django.conf import settings
 from django.conf.urls import url
-from django.contrib import admin
 from django.conf.urls.static import static
 from django.views import defaults as views_defaults
 from django.urls import re_path, include, path
@@ -26,7 +25,6 @@ from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
     path('main/', include('src.apps.main.urls')),
-    url(r'^admin/', admin.site.urls),
     re_path(r'^cms/', include(wagtailadmin_urls)),
 
     re_path(r'', include(wagtail_urls)),


### PR DESCRIPTION
Przez django admina da się poważnie zepsuć strukturę danych wagtaila, więc go wyłączam