### PR TITLE
Made contact form more flexible

### DIFF
--- a/src/apps/main/templatetags/main_tags.py
+++ b/src/apps/main/templatetags/main_tags.py
@@ -7,8 +7,13 @@ register = template.Library()
 
 
 @register.inclusion_tag('email_form.html', takes_context=True)
-def contact_form(context):
-    return {'form': ContactForm(request=context.get('request'))}
+def contact_form(context, default_text=True):
+    """
+    Returns basic email contact form. Param 'default_text' decides if the standard text block should be shown next
+    to form. If a custom message is preferable just set it ot False in template.
+    Ex. src/templates/projects/project_page.html
+    """
+    return {'form': ContactForm(request=context.get('request')), 'default_text': default_text}
 
 
 @register.inclusion_tag('email_with_attachment_form.html', takes_context=True)

--- a/src/templates/email_form.html
+++ b/src/templates/email_form.html
@@ -3,6 +3,7 @@
 <form enctype="multipart/form-data" method="post" action="{% url 'send_mail' %}">
     {% csrf_token %}
     <div class="columns">
+    {% if default_text %}
         <div class="column">
             {% blocktrans trimmed %}
             Need some help with your <b>project?</b><br>
@@ -10,6 +11,7 @@
             Want to change the world with us through <b>technology?</b><br>
             {% endblocktrans %}
         </div>
+    {% endif %}
         <div class="column">
             {{ form.as_p }}
             <div>

--- a/src/templates/projects/project_page.html
+++ b/src/templates/projects/project_page.html
@@ -45,12 +45,14 @@
 {#   Formularz Kontaktowy #}
     <div class="contact_form columns">
         <div class="column">
-            <p>{% trans 'You like this project?' %}</p>
-            <p>{% trans 'Have a similar idea?' %}</p>
-            <p>{% trans 'Looking for some tech support?' %}</p>
+            {% blocktrans trimmed %}
+            You like this <b>project?</b><br>
+            Have a similar <b>idea?</b><br>
+            Looking for some <b>tech support?</b><br>
+            {% endblocktrans %}
         </div>
         <div class="column">
-           {% contact_form %}
+           {% contact_form False %}
         </div>
       </div>
     <hr>


### PR DESCRIPTION
W podstronie projektu chcemy mieć inny tekst niż w innych miejscach, z związku z czym w template tagu dałem możliwość wyłączenia standardowego tekstu